### PR TITLE
clean code

### DIFF
--- a/compiler/src/main/java/sric/compiler/Compiler.java
+++ b/compiler/src/main/java/sric/compiler/Compiler.java
@@ -46,7 +46,7 @@ public class Compiler {
     public boolean genCode = true;
     public boolean print = true;
     
-    private HashMap<String, SModule> moduleCache = new HashMap<String, SModule>();
+    private HashMap<String, SModule> moduleCache = new HashMap<>();
     
     private HashMap<String, String> fmakeArgs = null;
     

--- a/compiler/src/main/java/sric/compiler/CompilerLog.java
+++ b/compiler/src/main/java/sric/compiler/CompilerLog.java
@@ -42,7 +42,7 @@ public class CompilerLog {
     }
     
     public boolean hasError() {
-        return errors.size() > 0;
+        return !errors.isEmpty();
     }
     
     public boolean printError() {

--- a/compiler/src/main/java/sric/compiler/ast/AstNode.java
+++ b/compiler/src/main/java/sric/compiler/ast/AstNode.java
@@ -169,8 +169,8 @@ public class AstNode {
     
     public static class TypeDef extends TopLevelDef {
         public ArrayList<Type> inheritances = null;
-        public ArrayList<FieldDef> fieldDefs = new ArrayList<FieldDef>();
-        public ArrayList<FuncDef> funcDefs = new ArrayList<FuncDef>();
+        public ArrayList<FieldDef> fieldDefs = new ArrayList<>();
+        public ArrayList<FuncDef> funcDefs = new ArrayList<>();
         public ArrayList<GenericParamDef> generiParamDefs = null;
         public Type enumBase = null;
         
@@ -256,7 +256,7 @@ public class AstNode {
             if ((this.flags & FConst.Virtual) != 0) {
                 return true;
             }
-            if (this.inheritances != null && this.inheritances.size() > 0) {
+            if (this.inheritances != null && !this.inheritances.isEmpty()) {
                 return true;
             }
             return false;
@@ -664,7 +664,7 @@ public class AstNode {
         }
         
         public boolean isLastReturnValue() {
-            if (stmts.size() == 0) {
+            if (stmts.isEmpty()) {
                 return false;
             }
             Stmt last = stmts.get(stmts.size()-1);

--- a/compiler/src/main/java/sric/compiler/ast/SModule.java
+++ b/compiler/src/main/java/sric/compiler/ast/SModule.java
@@ -70,7 +70,7 @@ public class SModule extends AstNode {
             throw new RuntimeException("Unknow outType");
         }
         
-        if (dependsStr.length() > 0) {
+        if (!dependsStr.isEmpty()) {
             var dependsA = dependsStr.split(",");
             for (String depStr : dependsA) {
                 depStr = depStr.trim();

--- a/compiler/src/main/java/sric/compiler/ast/Scope.java
+++ b/compiler/src/main/java/sric/compiler/ast/Scope.java
@@ -61,7 +61,7 @@ public class Scope extends AstNode {
         for (HashMap.Entry<String, ArrayList<AstNode>> entry : other.symbolTable.entrySet()) {
             for (AstNode anode : entry.getValue()) {
                 ArrayList<AstNode> nodes = symbolTable.get(entry.getKey());
-                if (nodes != null && nodes.size() > 0) {
+                if (nodes != null && !nodes.isEmpty()) {
                     continue;
                 }
                 put(entry.getKey(), anode);

--- a/compiler/src/main/java/sric/compiler/ast/Token.java
+++ b/compiler/src/main/java/sric/compiler/ast/Token.java
@@ -212,16 +212,10 @@ public class Token {
     }
     
     public boolean isAssign() {
-        switch (kind) {
-            case assign:
-            case assignPlus:
-            case assignMinus:
-            case assignStar:
-            case assignSlash:
-            case assignPercent:
-                return true;
-        }
-        return false;
+        return switch (kind) {
+            case assign, assignPlus, assignMinus, assignStar, assignSlash, assignPercent -> true;
+            default -> false;
+        };
     }
     
     @Override

--- a/compiler/src/main/java/sric/compiler/ast/Type.java
+++ b/compiler/src/main/java/sric/compiler/ast/Type.java
@@ -973,7 +973,7 @@ public class Type extends AstNode {
     }
     
     public Type toMutable() {
-        if (this.isImmutable == false) {
+        if (!this.isImmutable) {
             return this;
         }
         

--- a/compiler/src/main/java/sric/compiler/resolve/ErrorChecker.java
+++ b/compiler/src/main/java/sric/compiler/resolve/ErrorChecker.java
@@ -310,7 +310,7 @@ public class ErrorChecker extends CompilePass {
         
         //check constexpr
         if ((v.flags & FConst.ConstExpr) != 0) {
-            if (v.fieldType != null && v.fieldType.isImmutable == false) {
+            if (v.fieldType != null && !v.fieldType.isImmutable) {
                 err("constexpr must be const", v.loc);
             }
             if (v.initExpr == null) {


### PR DESCRIPTION
Switch has been fixed to a more concise version (as far as the Java version allows). Constructions like .size() > 0 have been replaced with isEmpty() / !isEmpty() etc.